### PR TITLE
Night_Wisp bombs demo patch

### DIFF
--- a/demos/bombs/bombs.cpp
+++ b/demos/bombs/bombs.cpp
@@ -3,7 +3,6 @@
 // Purpose:     Bombs game
 // Author:      P. Foggia 1996
 // Modified by: Wlodzimierz Skiba (ABX) since 2003
-// Modified by: Night_Wisp in 2022
 // Created:     1996
 // Copyright:   (c) 1996 P. Foggia
 // Licence:     wxWindows licence
@@ -11,9 +10,6 @@
 
 #include "wx/wxprec.h"
 
-#ifdef __BORLANDC__
-#   pragma hdrstop
-#endif
 
 #ifndef  WX_PRECOMP
 #   include "wx/wx.h"
@@ -25,28 +21,18 @@
 
 #include <stdlib.h>
 
-#ifndef __WXWINCE__
-#   include <time.h>
-#endif
+#include <time.h>
 
 #ifndef wxHAS_IMAGES_IN_RESOURCES
 #   include "bombs.xpm"
 #endif
 
-IMPLEMENT_APP(BombsApp)
-
-#ifdef __WXWINCE__
-    STDAPI_(__int64) CeGetRandomSeed();
-#endif
+wxIMPLEMENT_APP(BombsApp);
 
 // Called to initialize the program
 bool BombsApp::OnInit()
 {
-#ifdef __WXWINCE__
-    srand((unsigned) CeGetRandomSeed());
-#else
     srand((unsigned) time(NULL));
-#endif
 
     m_frame = new BombsFrame(&m_game);
 
@@ -55,7 +41,7 @@ bool BombsApp::OnInit()
     return true;
 }
 
-BEGIN_EVENT_TABLE(BombsFrame, wxFrame)
+wxBEGIN_EVENT_TABLE(BombsFrame, wxFrame)
     EVT_MENU(wxID_NEW,           BombsFrame::OnNewGame)
     EVT_MENU(bombsID_EASY,       BombsFrame::OnEasyGame)
     EVT_MENU(bombsID_MEDIUM,     BombsFrame::OnMediumGame)
@@ -63,7 +49,7 @@ BEGIN_EVENT_TABLE(BombsFrame, wxFrame)
     EVT_MENU(bombsID_EASYCORNER, BombsFrame::OnEasyCorner)
     EVT_MENU(wxID_EXIT,          BombsFrame::OnExit)
     EVT_MENU(wxID_ABOUT,         BombsFrame::OnAbout)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE()
 
 BombsFrame::BombsFrame(BombsGame *game)
     : wxFrame(NULL, wxID_ANY, wxT("wxBombs"), wxDefaultPosition,
@@ -219,11 +205,11 @@ void BombsFrame::OnEasyCorner(wxCommandEvent& WXUNUSED(event))
     NewGame(m_lastLevel, true);
 }
 
-BEGIN_EVENT_TABLE(BombsCanvas, wxPanel)
+wxBEGIN_EVENT_TABLE(BombsCanvas, wxPanel)
     EVT_PAINT(BombsCanvas::OnPaint)
     EVT_MOUSE_EVENTS(BombsCanvas::OnMouseEvent)
     EVT_CHAR(BombsCanvas::OnChar)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE()
 
 BombsCanvas::BombsCanvas(wxFrame *parent, BombsGame *game)
     : wxPanel(parent, wxID_ANY)
@@ -231,8 +217,7 @@ BombsCanvas::BombsCanvas(wxFrame *parent, BombsGame *game)
     m_game = game;
     int sx, sy;
     wxClientDC dc(this);
-    wxFont font= BOMBS_FONT;
-    dc.SetFont(font);
+    dc.SetFont(BOMBS_FONT);
 
     wxCoord chw, chh;
     wxString buf = wxT("M");

--- a/demos/bombs/bombs.cpp
+++ b/demos/bombs/bombs.cpp
@@ -3,6 +3,7 @@
 // Purpose:     Bombs game
 // Author:      P. Foggia 1996
 // Modified by: Wlodzimierz Skiba (ABX) since 2003
+// Modified by: Night_Wisp in 2022
 // Created:     1996
 // Copyright:   (c) 1996 P. Foggia
 // Licence:     wxWindows licence


### PR DESCRIPTION
Fix two minor errors in the Bombs demo.

Error 1: When enabling/disabling easy corner, the enable/disable text was mixed up. This resulted in being asked to confirm disabling easy corner, when it was being enabled, and vice versa.
Error 2: When choosing not to switch easy corner, the checkmark in the menu showing it's state still swapped.

Fix 1: Swap the text for enable/disable in the confirm easy mode toggle dialog box.
Fix 2: Call GetMenuBar()->Check(bombsID_EASYCORNER, m_easyCorner); (Check always returns void, and GetMenuBar is only called from the MenuBar, after it's been set up) to set the checkmark's state, when needed.